### PR TITLE
edit tar logic

### DIFF
--- a/core/banner.go
+++ b/core/banner.go
@@ -2,7 +2,7 @@ package core
 
 const (
 	Name    = "aquatone"
-	Version = "1.7.0"
+	Version = "1.7.1"
 	Author  = "Michael Henriksen"
 	Website = "https://github.com/michenriksen/aquatone"
 )


### PR DESCRIPTION
При одновременном запуске нескольких aquatone процессов могли происходить проблемы связанные с созданием архива (флаг `-tar`). Один процесс мог удалить временный архив другого в папке `tmp`, так как имеют идентичные имена.